### PR TITLE
Fix: invalid stream redirection

### DIFF
--- a/src/pyfxtran/__init__.py
+++ b/src/pyfxtran/__init__.py
@@ -25,7 +25,7 @@ def run(filename, options=None, verbose=False):
     """
 
     parser = os.path.join(Path.home(), f'.fxtran_{FXTRAN_VERSION}')
-    out_stream = subprocess.STDOUT if verbose else subprocess.DEVNULL
+    out_stream = None if verbose else subprocess.DEVNULL
 
     # Installation
     if not os.path.exists(parser):


### PR DESCRIPTION
Within the PR https://github.com/SebastienRietteMTO/pyfxtran/pull/2 I made an error, where I was passing `subprocess.STDOUT` to `stdout` argument of the `subprocess.run()` function. However, according to the [documentation](https://docs.python.org/3/library/subprocess.html), the `subprocess.STDOUT` can only be passed to the `stderr` argument:

> subprocess.STDOUT
>     Special value that can be used as the stderr argument to [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) and indicates that standard error should go into the same handle as standard output.

This mistake of mine has caused a random and bizarre, at first, error that we have observed e.g. on spirit(x) and MacOS systems:

```shell
OSError: [Errno 9] Bad file descriptor: '/tmp/tmp9m2cj86d'
```

which seems to point to a problem with the [tempfile.TemporaryDirectory()](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory), but in fact, it is a problem with an invalid `stdout` value!
It is enough to set `stdout`/`stderr` to `None` if we want to display them.